### PR TITLE
Import orphan instances as quick-fix for issue #7.

### DIFF
--- a/src/Network/MessagePack/Rpc.hs
+++ b/src/Network/MessagePack/Rpc.hs
@@ -19,6 +19,11 @@ import qualified Network.MessagePack.Interface.Internal as I
 import qualified Network.MessagePack.Types.Client       as Client
 import qualified Network.MessagePack.Types.Server       as Server
 
+-- Import orphan instances for RpcType and IsReturnType.
+-- TODO(SX91): Avoid orphan instances. See issue #7.
+import           Network.MessagePack.Client.Basic       ()
+import           Network.MessagePack.Server.Basic       ()
+
 
 class RpcService rpc where
   type ClientMonad rpc :: * -> *


### PR DESCRIPTION
Ideally we would not have orphan instances. PR #5 introduced them. See
https://stackoverflow.com/questions/3079537/orphaned-instances-in-haskell
for some reasons why we want to avoid them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-rpc/8)
<!-- Reviewable:end -->
