### PR TITLE
Add GHC warning flags to bazel build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,11 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
 haskell_library(
     name = "hs-msgpack-rpc",
     srcs = glob(["src/**/*.*hs"]),
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
     prebuilt_dependencies = [
         "base",
         "binary",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ cache:
 - '%APPDATA%\ghc'
 
 install:
-- choco install ghc
+- choco install ghc --version 8.2.2
 - refreshenv
 
 build_script:

--- a/src/Network/MessagePack/Client.hs
+++ b/src/Network/MessagePack/Client.hs
@@ -17,7 +17,7 @@ module Network.MessagePack.Client (
 
 import           Control.Applicative                 (Applicative, pure)
 import           Control.Monad                       (when)
-import           Control.Monad.Catch                 (MonadCatch, catch)
+import           Control.Monad.Catch                 (catch)
 import qualified Data.ByteString                     as S
 import           Data.Default.Class                  (Default (..))
 import           Data.Default.Instances.Base         ()

--- a/src/Network/MessagePack/Client/Basic.hs
+++ b/src/Network/MessagePack/Client/Basic.hs
@@ -42,18 +42,12 @@ module Network.MessagePack.Client.Basic (
   , RpcType (..)
   ) where
 
-import           Control.Monad.Catch                 (MonadThrow, throwM)
 import qualified Control.Monad.State.Strict          as CMS
 import qualified Data.ByteString                     as S
 import           Data.Conduit                        (($$+))
 import           Data.Conduit.Network                (appSink, appSource,
                                                       clientSettings,
                                                       runTCPClient)
-import           Data.MessagePack                    (MessagePack, Object,
-                                                      fromObject, toObject)
-import qualified Data.MessagePack.Types.Result       as R
-import           Data.Text                           (Text)
-import qualified Data.Text                           as T
 
 import           Network.MessagePack.Client.Internal
 import           Network.MessagePack.Types.Client

--- a/src/Network/MessagePack/Interface/Internal.hs
+++ b/src/Network/MessagePack/Interface/Internal.hs
@@ -9,7 +9,6 @@
 module Network.MessagePack.Interface.Internal where
 
 import           Control.Monad.Catch                   (MonadThrow)
-import           Control.Monad.Trans                   (MonadIO, liftIO)
 import           Data.Text                             (Text)
 import           Data.Typeable                         (Typeable)
 

--- a/src/Network/MessagePack/Internal/TypeUtil.hs
+++ b/src/Network/MessagePack/Internal/TypeUtil.hs
@@ -4,10 +4,9 @@ module Network.MessagePack.Internal.TypeUtil
   ( typeName
   ) where
 
-import qualified Data.List.Utils as List
-import qualified Data.Text       as T
-import           Data.Typeable   (Typeable)
-import qualified Data.Typeable   as Typeable
+import qualified Data.Text     as T
+import           Data.Typeable (Typeable)
+import qualified Data.Typeable as Typeable
 
 
 typeName :: Typeable a => a -> T.Text

--- a/src/Network/MessagePack/Server/Basic.hs
+++ b/src/Network/MessagePack/Server/Basic.hs
@@ -75,7 +75,6 @@ import           Data.MessagePack                       (MessagePack, Object,
                                                          fromObject, toObject)
 import qualified Data.MessagePack.Types.Result          as R
 import           Data.Monoid                            ((<>))
-import           Data.Text                              (Text)
 import qualified Data.Text                              as T
 import           Data.Traversable                       (sequenceA)
 import           Network.Socket                         (SocketOption (ReuseAddr),


### PR DESCRIPTION
`-Werror` is fine here because we control the exact version of GHC we are
building with (currently 8.2.2), so there is no risk of getting different
warnings on different installations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-rpc/17)
<!-- Reviewable:end -->
