### PR TITLE
Use hs-tools scripts to simplify Travis script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,35 +11,26 @@ env:
     - secure: "JDHHQhgYlQldCfS2aAmresi1wcfgFAobSHXG4QrcOiaIz3d12p4ybccgY31CE52dWTWwKdWXD+3pCVKRwUbEwj1FXvOTYn12E1ykZaewuo/10j6Nnjqa0LUUC/XmGgnDmpIEX8vs0xwgpeFUQmQQUT27G3eeBkPrdLbAW2wfXV52QXzrrajy7Q4F27h8i0GcKUFyLij0V/jOya5zuJddxcCviM383KN0e0RTk4L4HMKc905aPy+2p4fiPGIrthWkdvUZlbcPWLpSTIk5ElcMU3N3gOfncUpLWj9hzubLLVUa0SHa3yu1UvVoDZhJdHRzCt+oeceYOtfhZ1CMO9r9z2QgCsIrd+mRCroIsG/OOTC0dwxN726EAXM1beK7ev3mGWluwEbvPvbKv9Le/FXSIi6N+l9ER9oteh+prRDXNyeHb07FV8Sd+55Js3zQw6dz0fNx5zLLhT1aTQt9JhwQlZ1fRoSwTZTFubFYVGvYJVQiNqFZhCa94CeWiPoAgSCe/OTHZMf0/jPFgCPl4/RM5OaUXkd4mceO4XXZGn+HYP2duInWBg2uI0o8MUQwdObkbpr+0ZxoIxio58Ic/NWunRNcvfG4I+U0NNBgwrP24Xanr09jQO89tdFKCX1iIGmsSt1ka+oIEI81vr/PGHuoU3Qe5m5f8UhkoPclMuDzG4M="
 
 cache:
+  timeout: 600
   directories:
+    - $HOME/.local
     - $HOME/.stack
 
-before_install:
-  - export PATH=$HOME/.local/bin:$PATH
-  - travis_retry curl -L https://github.com/TokTok/hs-tools/releases/download/v0.6/hs-tools-v0.6.tar.gz | tar xz -C $HOME
-
 script:
-  - hlint .
-  - stylish-haskell-lhs -i .
-  - git diff --exit-code
-  - stack --no-terminal test --coverage
-  - shc msgpack-rpc-conduit testsuite
-  - stack sdist --tar-dir .
+  - bash <(travis_retry curl -s https://raw.githubusercontent.com/TokTok/hs-tools/master/bin/travis-haskell) script
+  - eval $(travis-haskell env)
 
 deploy:
   provider: releases
   token:
     secure: "tBnLJar+vXhTgYW5/Euqe27vGvefC6HX8pPegNjUdyxQA1WFoMz4J78hfR3xQe0e76CXj/Rdk3kwbc+mqeWgIj2r/bxCSSQ3GuXCQw842NEohpQT0xKG60hsti6X2mcN6prrJ4OLaAjo1Nl54LLe6d7WJbnMqG4omVtBPq/LWE53e7SIOv78WdMGu8UI7kYbzl+NMDhSgA4ODjRIc9bFpqd6eReIkPUfRDQRSIKWQz3ifWtiuDOEZkWymkX/9hEii+rNMnkkEBShqs06QFZmffHgRp0b/rYd+EOgpvDDMhtdQDTK6RyjYn12mQHJN0Vlfw/5tkaMv7CFcKbxKN5V/Spf7h6h7yOJMLyKhZCL4NCEhFQHbQr1vy1VQy81AnEZZtVWc0yfjc8iq+W8oJnt+bGn3SFnYrntZomVwj+/+9cOYknoqY6OB9IVnEUwKfdXNLrdy6fttBXzIhhYzmdARChglW/s8CRqGjspzZ5Dn+FzZdehYDeW/of8eBfMfhRZ+wfNswAbxU/JOSzNOk4yMidmoY2W2jBhY1YV7tNVDInuuGuLuiZxzrWmC3/6+qwPGYud2WWN0Xu01Qf7/PzXkgvdJRK1dhMZl/t/pfkcbbAUPeyVgEu5LfDcsnJOmCCUJ0FqWEk5dCQOGQ2+OfcM1DzdaCFTTL9jxgrnRzsPluk="
-  file: msgpack-rpc-conduit-0.0.6.tar.gz
+  file: $PACKAGE-$VERSION.tar.gz
   skip_cleanup: true
   on:
     repo: TokTok/hs-msgpack-rpc-conduit
     tags: true
 
-after_deploy:
-  - mkdir -p "$HOME/.stack/upload"
-  - echo "{\"username\":\"$HACKAGE_USERNAME\",\"password\":\"$HACKAGE_PASSWORD\"}" > $HOME/.stack/upload/credentials.json
-  - stack --no-terminal upload .
+after_deploy: travis-haskell deploy
 
 # Only build pull requests and releases, don't build master on pushes,
 # except through api or cron.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,12 +3,9 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-VERSION = "0.0.6"
-
 project(
     license = "hs-msgpack",
     standard_travis = True,
-    version = VERSION,
 )
 
 haskell_library(
@@ -16,7 +13,7 @@ haskell_library(
     srcs = glob(["src/**/*.*hs"]),
     compiler_flags = ["-Wno-unused-imports"],
     src_strip_prefix = "src",
-    version = VERSION,
+    version = "0.0.6",
     visibility = ["//visibility:public"],
     deps = [
         "//hs-msgpack-binary",


### PR DESCRIPTION
Also, we no longer need to write the version number to .travis.yml, because
we can infer it from the travis tag. We couldn't do that before, because it's
a bit of code we don't want to repeat in every repo. Now that it's common, we
can write it and download it into each repo's build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-rpc-conduit/37)
<!-- Reviewable:end -->
