### PR TITLE
chore(deps): loosen dependency restriction on "network" to <3.1

### DIFF
--- a/msgpack-rpc-conduit.cabal
+++ b/msgpack-rpc-conduit.cabal
@@ -59,7 +59,7 @@ library
     , msgpack-binary                    >= 0.0.11
     , msgpack-types                     >= 0.0.1
     , mtl
-    , network                           < 3
+    , network                           < 3.1
     , text
     , unliftio-core
 
@@ -79,4 +79,4 @@ test-suite testsuite
     , hspec
     , msgpack-rpc-conduit
     , mtl
-    , network                           < 3
+    , network                           < 3.1


### PR DESCRIPTION
as it builds just fine against 3.0.1.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-rpc-conduit/43)
<!-- Reviewable:end -->
