### PR TITLE
perf: Use StrictData for all modules that define data types.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.15
+    image: toxchat/toktok-stack:0.0.19
     cpu: 2
-    memory: 4G
+    memory: 6G
   configure_script:
     - /src/workspace/tools/inject-repo hs-msgpack-rpc-conduit
   test_all_script:

--- a/src/Network/MessagePack/Capabilities.hs
+++ b/src/Network/MessagePack/Capabilities.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StrictData    #-}
 module Network.MessagePack.Capabilities
     ( ServerCapability (..)
     , ClientCapability (..)

--- a/src/Network/MessagePack/Client/Internal.hs
+++ b/src/Network/MessagePack/Client/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Network.MessagePack.Client.Internal where

--- a/src/Network/MessagePack/Interface.hs
+++ b/src/Network/MessagePack/Interface.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE Safe                  #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TypeFamilies          #-}
 module Network.MessagePack.Interface
     ( Interface (..)
@@ -36,8 +37,8 @@ import qualified Network.MessagePack.Types.Server as Server
 
 
 data Interface f = Interface
-  { name :: !Text
-  , docs :: !(Doc f)
+  { name :: Text
+  , docs :: Doc f
   }
 
 

--- a/src/Network/MessagePack/Rpc.hs
+++ b/src/Network/MessagePack/Rpc.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Safe                  #-}
+{-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TypeFamilies          #-}
 module Network.MessagePack.Rpc
   ( I.Doc (..)

--- a/src/Network/MessagePack/Server/Basic.hs
+++ b/src/Network/MessagePack/Server/Basic.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE Trustworthy                #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/src/Network/MessagePack/Types/Error.hs
+++ b/src/Network/MessagePack/Types/Error.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StrictData         #-}
 module Network.MessagePack.Types.Error
   ( RpcError (..)
   , ServerError (..)
@@ -12,9 +13,9 @@ import           Data.Typeable     (Typeable)
 
 -- | RPC error type
 data RpcError
-  = RemoteError !Object           -- ^ Server error
-  | ResultTypeError !Text !Object -- ^ Result type mismatch
-  | ProtocolError !Text           -- ^ Protocol error
+  = RemoteError Object          -- ^ Server error
+  | ResultTypeError Text Object -- ^ Result type mismatch
+  | ProtocolError Text          -- ^ Protocol error
   deriving (Show, Eq, Ord, Typeable)
 
 instance Exception RpcError

--- a/src/Network/MessagePack/Types/Result.hs
+++ b/src/Network/MessagePack/Types/Result.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE Safe              #-}
+{-# LANGUAGE StrictData        #-}
 module Network.MessagePack.Types.Result
     ( Result (..)
     ) where

--- a/src/Network/MessagePack/Types/Server.hs
+++ b/src/Network/MessagePack/Types/Server.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Safe                  #-}
+{-# LANGUAGE StrictData            #-}
 module Network.MessagePack.Types.Server
   ( MethodVal (..)
   , MethodDocs (..)
@@ -14,21 +15,21 @@ import           Data.Text        (Text)
 
 
 data MethodVal = MethodVal
-  { valName :: !Text
-  , valType :: !Text
+  { valName :: Text
+  , valType :: Text
   }
   deriving (Show, Read, Eq)
 
 data MethodDocs = MethodDocs
-  { methodArgs :: ![MethodVal]
-  , methodRetv :: !MethodVal
+  { methodArgs :: [MethodVal]
+  , methodRetv :: MethodVal
   }
   deriving (Show, Read, Eq)
 
 -- ^ MessagePack RPC method
 data Method m = Method
-  { methodName :: !Text
-  , methodDocs :: !MethodDocs
+  { methodName :: Text
+  , methodDocs :: MethodDocs
   , methodBody :: [Object] -> m Object
   }
 


### PR DESCRIPTION
I've added StrictData to some modules that don't currently define data
types, mostly by mistake, but it doesn't harm and avoids missing it in
the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-rpc-conduit/46)
<!-- Reviewable:end -->
