### PR TITLE
chore: Use toktok-stack 0.0.23 for cirrus builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,13 +1,13 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.19
+    image: toxchat/toktok-stack:0.0.23-third_party
     cpu: 2
     memory: 6G
   configure_script:
     - /src/workspace/tools/inject-repo hs-msgpack-rpc-conduit
   test_all_script:
-    - bazel test -k
+    - cd /src/workspace && bazel test -k
         --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --config=release
         //hs-msgpack-rpc-conduit/...


### PR DESCRIPTION
This version has pre-built third party binaries, speeding up the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-rpc-conduit/47)
<!-- Reviewable:end -->
